### PR TITLE
Created foreign key in team_invites

### DIFF
--- a/src/database/migrations.stub
+++ b/src/database/migrations.stub
@@ -28,6 +28,10 @@ class TeamworkSetupTables extends Migration
             $table->string('accept_token');
             $table->string('deny_token');
             $table->timestamps();
+            $table->foreign( 'team_id' )
+                ->references( 'id' )
+                ->on( \Config::get( 'teamwork.teams_table' ) )
+                ->onDelete( 'cascade' );
         });
 
         Schema::create( \Config::get( 'teamwork.teams_table' ), function ( $table )


### PR DESCRIPTION
Created foreign key in team_invites related to team. When I invite a user to team, after that I will delete this team and I'm trying to show name of team from invite, I get an error.
