### PR TITLE
Add inviter relation to TeamInvite

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ In addition to these attributes, the model has these relations:
 
 - `user()` &mdash; one-to-one relation using the `email` as a unique identifier on the User model.
 - `team()` &mdash; one-to-one relation return the Team, that invite was aiming for.
+- `inviter()` &mdash; one-to-one relation return the User, that created the invite.
 
 **Note:**
 The `inviteToTeam` method will **not** check if the given email already has a pending invite. To check for pending invites use the `hasPendingInvite` method on the `Teamwork` facade.

--- a/src/Mpociot/Teamwork/Traits/TeamworkTeamInviteTrait.php
+++ b/src/Mpociot/Teamwork/Traits/TeamworkTeamInviteTrait.php
@@ -31,4 +31,14 @@ trait TeamworkTeamInviteTrait
         return $this->hasOne( Config::get( 'teamwork.user_model' ), 'email', 'email' );
     }
 
+    /**
+     * Has-One relations with the user model.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function inviter()
+    {
+        return $this->hasOne( Config::get( 'teamwork.user_model' ), 'id', 'user_id' );
+    }
+
 }

--- a/tests/TeamworkTeamInviteTraitTest.php
+++ b/tests/TeamworkTeamInviteTraitTest.php
@@ -42,6 +42,21 @@ class TeamworkTeamInviteTraitTest extends PHPUnit_Framework_TestCase
         $this->assertEquals( [], $stub->user() );
     }
 
+    public function testGetInviter()
+    {
+        Config::shouldReceive('get')
+            ->once()
+            ->with('teamwork.user_model')
+            ->andReturn('User');
+
+        $stub = m::mock( 'TestUserTeamInviteTraitStub[hasOne]' );
+        $stub->shouldReceive('hasOne')
+            ->once()
+            ->with('User', 'id', 'user_id' )
+            ->andReturn( [] );
+        $this->assertEquals( [], $stub->inviter() );
+    }
+
 }
 
 class TestUserTeamInviteTraitStub extends Illuminate\Database\Eloquent\Model {


### PR DESCRIPTION
Allow you to access the user that sent an invite. Useful for showing to a new user creating an account like so:

`$invite->inviter->name .  'invited you to join....'`
