### PR TITLE
Allow dev to apply pivot data on attaching a team.

### DIFF
--- a/src/Mpociot/Teamwork/Contracts/TeamworkUserInterface.php
+++ b/src/Mpociot/Teamwork/Contracts/TeamworkUserInterface.php
@@ -49,8 +49,9 @@ interface TeamworkUserInterface
      * Alias to eloquent many-to-many relation's attach() method.
      *
      * @param mixed $team
+     * @param array $pivotData
      */
-    public function attachTeam( $team );
+    public function attachTeam( $team, $pivotData = [] );
 
     /**
      * Alias to eloquent many-to-many relation's detach() method.

--- a/src/Mpociot/Teamwork/Traits/UserHasTeams.php
+++ b/src/Mpociot/Teamwork/Traits/UserHasTeams.php
@@ -130,9 +130,10 @@ trait UserHasTeams
      * Alias to eloquent many-to-many relation's attach() method.
      *
      * @param mixed $team
+     * @param array $pivotData
      * @return $this
      */
-    public function attachTeam( $team )
+    public function attachTeam( $team, $pivotData = [] )
     {
         $team        = $this->retrieveTeamId( $team );
         /**
@@ -146,7 +147,7 @@ trait UserHasTeams
         }
         if( !$this->teams->contains( $team ) )
         {
-            $this->teams()->attach( $team );
+            $this->teams()->attach( $team, $pivotData );
         }
         return $this;
     }


### PR DESCRIPTION
I was unable to come up with a way to unit test this change because I am unsure how to test the `withPivot` method with Mockery (also not sure if there were any database migrations happening, or if Mockery just simulates a database).

I could also apply the same change to the `attachTeams` method, but that would require everyone else change the format of the array they send to that method - which seems a bit rude.
