### PR TITLE
Changed the order of the database migrations

### DIFF
--- a/src/database/migrations.stub
+++ b/src/database/migrations.stub
@@ -18,21 +18,6 @@ class TeamworkSetupTables extends Migration
             $table->integer( 'current_team_id' )->unsigned()->nullable();
         } );
 
-        Schema::create( \Config::get( 'teamwork.team_invites_table' ), function(Blueprint $table)
-        {
-            $table->increments('id');
-            $table->integer('user_id')->unsigned();
-            $table->integer('team_id')->unsigned();
-            $table->enum('type', ['invite', 'request']);
-            $table->string('email');
-            $table->string('accept_token');
-            $table->string('deny_token');
-            $table->timestamps();
-            $table->foreign( 'team_id' )
-                ->references( 'id' )
-                ->on( \Config::get( 'teamwork.teams_table' ) )
-                ->onDelete( 'cascade' );
-        });
 
         Schema::create( \Config::get( 'teamwork.teams_table' ), function ( $table )
         {
@@ -56,6 +41,22 @@ class TeamworkSetupTables extends Migration
 
             $table->foreign( 'team_id' )->references( 'id' )->on( \Config::get( 'teamwork.teams_table' ) );
         } );
+
+        Schema::create( \Config::get( 'teamwork.team_invites_table' ), function(Blueprint $table)
+        {
+            $table->increments('id');
+            $table->integer('user_id')->unsigned();
+            $table->integer('team_id')->unsigned();
+            $table->enum('type', ['invite', 'request']);
+            $table->string('email');
+            $table->string('accept_token');
+            $table->string('deny_token');
+            $table->timestamps();
+            $table->foreign( 'team_id' )
+                ->references( 'id' )
+                ->on( \Config::get( 'teamwork.teams_table' ) )
+                ->onDelete( 'cascade' );
+        });
     }
 
     /**


### PR DESCRIPTION
Fixed the issue I reported here 
[https://github.com/mpociot/teamwork/issues/35](https://github.com/mpociot/teamwork/issues/35) 

It's a very simple change all it does is move the "team invite" table to the bottom of the migration to prevent the error message I was receiving. 
