### PR TITLE
dedicated `boot` method

### DIFF
--- a/src/Mpociot/Teamwork/Traits/UsedByTeams.php
+++ b/src/Mpociot/Teamwork/Traits/UsedByTeams.php
@@ -21,10 +21,8 @@ trait UsedByTeams
     /**
      * Boot the global scope
      */
-    protected static function boot()
+    protected static function bootUsedByTeams()
     {
-        parent::boot();
-
         static::addGlobalScope('team', function (Builder $builder) {
             static::teamGuard();
 


### PR DESCRIPTION
Use dedicated `boot` method to avoid collisions with other traits
