### PR TITLE
Case of extending TeamworkTeam

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The `Team` model has two main attributes:
 
 The `owner_id` is an optional attribute and is nullable in the database.
 
+When extending TeamworkTeam, remember to change the `team_model` variable in `config/teamwork.php` to your new model. For instance: `'team_model' => App\Team::class`
+
 <a name="user" />
 #### User
 


### PR DESCRIPTION
I extended TeamworkTeam to App\Team as suggested and added a slug field. I had no idea why it wasn't saving my slug until debugging brought me to the team_model variable. I thought this would be a useful note.
