### PR TITLE
Modified currentTeam() method and added currentTeam attribute

### DIFF
--- a/src/Mpociot/Teamwork/Traits/UserHasTeams.php
+++ b/src/Mpociot/Teamwork/Traits/UserHasTeams.php
@@ -27,13 +27,23 @@ trait UserHasTeams
     }
 
     /**
-     * has-one relation with the current selected team model.
+     * Accessor for the currentTeam method.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return Mpociot\Teamwork\TeamworkTeam
+     */
+    public function getCurrentTeamAttribute()
+    {
+        return $this->currentTeam();
+    }
+
+    /**
+     * Get the team that user is currently viewing.
+     *
+     * @return Many Mpociot\Teamwork\TeamworkTeam
      */
     public function currentTeam()
     {
-        return $this->hasOne( Config::get( 'teamwork.team_model' ), 'id', 'current_team_id' );
+        return $this->teams->find($this->current_team_id);
     }
 
     /**

--- a/tests/UserHasTeamsTraitTest.php
+++ b/tests/UserHasTeamsTraitTest.php
@@ -81,9 +81,12 @@ class UserHasTeamsTraitTest extends Orchestra\Testbench\TestCase
 
         $this->user->attachTeam($team);
 
+        $currentTeam = $this->user->currentTeam;
+        unset($currentTeam->pivot);
+
         // Reload relation
         $this->assertCount(1, $this->user->teams);
-        $this->assertEquals(TeamworkTeam::find(1)->toArray(), $this->user->currentTeam->toArray());
+        $this->assertEquals(TeamworkTeam::find(1)->toArray(), $currentTeam->toArray());
     }
 
     public function testCanAttachTeamAsArrayToUser()
@@ -92,9 +95,12 @@ class UserHasTeamsTraitTest extends Orchestra\Testbench\TestCase
 
         $this->user->attachTeam($team->toArray());
 
+        $currentTeam = $this->user->currentTeam;
+        unset($currentTeam->pivot);
+
         // Reload relation
         $this->assertCount(1, $this->user->teams);
-        $this->assertEquals(TeamworkTeam::find(1)->toArray(), $this->user->currentTeam->toArray());
+        $this->assertEquals(TeamworkTeam::find(1)->toArray(), $currentTeam->toArray());
     }
 
     public function testCanAttachTeamAsIDToUser()
@@ -103,9 +109,12 @@ class UserHasTeamsTraitTest extends Orchestra\Testbench\TestCase
 
         $this->user->attachTeam($team->getKey());
 
+        $currentTeam = $this->user->currentTeam;
+        unset($currentTeam->pivot);
+
         // Reload relation
         $this->assertCount(1, $this->user->teams);
-        $this->assertEquals(TeamworkTeam::find(1)->toArray(), $this->user->currentTeam->toArray());
+        $this->assertEquals(TeamworkTeam::find(1)->toArray(), $currentTeam->toArray());
     }
 
     public function testCanSetPivotDataOnAttachTeamMethod()


### PR DESCRIPTION
While having issues trying to use `withPivot()` on `currentTeam` it would just error out. Turns out `hasOne` doesn't have that method so decided to fix the issue so you can grab data from the pivot table.