### PR TITLE
Laravel 55 composer updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Mpociot\\Teamwork": "src/"
+            "Mpociot\\Teamwork\\": "src/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable" : true,
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "~5.4"
+        "laravel/framework": "~5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
     "minimum-stability": "dev",
     "prefer-stable" : true,
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0.0",
         "laravel/framework": "~5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
         "mockery/mockery": "dev-master",
-        "illuminate/database": "~5.0",
+        "illuminate/database": "~5.5",
         "orchestra/testbench": "3.4.*@dev"
     },
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Mpociot\\Teamwork": "src/"
         }
     },
@@ -36,5 +36,12 @@
             "tests/models/User.php",
             "tests/models/Task.php"
         ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mpociot\\Teamwork\\TeamworkServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
PHP and Laravel version have been fixed. The new auto discovering service package feature has been included as well. Updated autoloading to PSR-4.

A few of the packages should be looked at potentially, such as PHPUnit. L55 requires 6.0 now.