### PR TITLE
Add validation of name and email

### DIFF
--- a/src/stubs/controllers/TeamController.stub
+++ b/src/stubs/controllers/TeamController.stub
@@ -42,6 +42,10 @@ class TeamController extends Controller
      */
     public function store(Request $request)
     {
+        $request->validate([
+            'name' => 'required|string',
+        ]);
+
         $teamModel = config('teamwork.team_model');
 
         $team = $teamModel::create([
@@ -99,6 +103,10 @@ class TeamController extends Controller
      */
     public function update(Request $request, $id)
     {
+        $request->validate([
+            'name' => 'required|string',
+        ]);
+
         $teamModel = config('teamwork.team_model');
 
         $team = $teamModel::findOrFail($id);

--- a/src/stubs/controllers/TeamMemberController.stub
+++ b/src/stubs/controllers/TeamMemberController.stub
@@ -63,6 +63,10 @@ class TeamMemberController extends Controller
      */
     public function invite(Request $request, $team_id)
     {
+        $request->validate([
+            'email' => 'required|email',
+        ]);
+
         $teamModel = config('teamwork.team_model');
         $team = $teamModel::findOrFail($team_id);
 
@@ -80,13 +84,13 @@ class TeamMemberController extends Controller
                 'email' => 'The email address is already invited to the team.'
             ]);
         }
-        
+
         return redirect(route('teams.members.show', $team->id));
     }
 
     /**
      * Resend an invitation mail.
-     * 
+     *
      * @param $invite_id
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */


### PR DESCRIPTION
This PR adds a request validation to the controller stubs for the name and email entered by the user when creating a team or an invite.