### PR TITLE
Fixes #90

### DIFF
--- a/src/Mpociot/Teamwork/Middleware/TeamOwner.php
+++ b/src/Mpociot/Teamwork/Middleware/TeamOwner.php
@@ -15,8 +15,14 @@ class TeamOwner
      */
     public function handle($request, Closure $next)
     {
-        if (!auth()->user()->isOwnerOfTeam(auth()->user()->currentTeam)) {
-            return back();
+        if (!$request->id) {
+            abort(404);
+        }
+
+        $team = Team::findOrFail($request->id);
+
+        if (!auth()->user()->isOwnerOfTeam($team)) {
+            return abort(403);
         }
 
         return $next($request);


### PR DESCRIPTION
1. Checks if there is an `id` in the URL and throws a 404 if not.
2. If there is then load that team and check for ownership.
3. If the current authenticated user is not that team's owner throw a 403.