### PR TITLE
Updated owner() method with the correct relationship

### DIFF
--- a/src/Mpociot/Teamwork/Traits/TeamworkTeamTrait.php
+++ b/src/Mpociot/Teamwork/Traits/TeamworkTeamTrait.php
@@ -36,13 +36,13 @@ trait TeamworkTeamTrait
      * Has-One relation with the user model.
      * This indicates the owner of the team
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function owner()
     {
         $userModel   = Config::get( 'teamwork.user_model' );
         $userKeyName = ( new $userModel() )->getKeyName();
-        return $this->hasOne(Config::get('teamwork.user_model'), $userKeyName, "owner_id");
+        return $this->belongsTo(Config::get('teamwork.user_model'), "owner_id", $userKeyName);
     }
 
     /**

--- a/tests/TeamworkTeamTraitTest.php
+++ b/tests/TeamworkTeamTraitTest.php
@@ -61,8 +61,8 @@ class TeamworkTeamTraitTest extends PHPUnit_Framework_TestCase
             ->andReturn('TestUser');
 
 
-        $stub = m::mock( 'TestUserTeamTraitStub[hasOne]' );
-        $stub->shouldReceive('hasOne')
+        $stub = m::mock( 'TestUserTeamTraitStub[belongsTo]' );
+        $stub->shouldReceive('belongsTo')
             ->once()
             ->with('User', 'user_id', 'owner_id' )
             ->andReturn( [] );


### PR DESCRIPTION
`TeamworkTeamTrait::owner()` method now returns a `\Illuminate\Database\Eloquent\Relations\BelongsTo` to be inline with current standards on relationships

resolves #99 