### PR TITLE
Updated owner() method with the correct relationship (#100 continued)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable" : true,
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*""
+        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable" : true,
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.5.*|5.6.*|5.7.*"
+        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*""
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",

--- a/src/Mpociot/Teamwork/Traits/TeamworkTeamTrait.php
+++ b/src/Mpociot/Teamwork/Traits/TeamworkTeamTrait.php
@@ -36,13 +36,13 @@ trait TeamworkTeamTrait
      * Has-One relation with the user model.
      * This indicates the owner of the team
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function owner()
     {
         $userModel   = Config::get( 'teamwork.user_model' );
         $userKeyName = ( new $userModel() )->getKeyName();
-        return $this->hasOne(Config::get('teamwork.user_model'), $userKeyName, "owner_id");
+        return $this->belongsTo(Config::get('teamwork.user_model'), "owner_id", $userKeyName);
     }
 
     /**

--- a/tests/TeamworkTeamTraitTest.php
+++ b/tests/TeamworkTeamTraitTest.php
@@ -64,7 +64,7 @@ class TeamworkTeamTraitTest extends PHPUnit_Framework_TestCase
         $stub = m::mock( 'TestUserTeamTraitStub[belongsTo]' );
         $stub->shouldReceive('belongsTo')
             ->once()
-            ->with('User', 'user_id', 'owner_id' )
+            ->with('User', 'owner_id', 'user_id' )
             ->andReturn( [] );
         $this->assertEquals( [], $stub->owner() );
     }

--- a/tests/TeamworkTeamTraitTest.php
+++ b/tests/TeamworkTeamTraitTest.php
@@ -61,8 +61,8 @@ class TeamworkTeamTraitTest extends PHPUnit_Framework_TestCase
             ->andReturn('TestUser');
 
 
-        $stub = m::mock( 'TestUserTeamTraitStub[hasOne]' );
-        $stub->shouldReceive('hasOne')
+        $stub = m::mock( 'TestUserTeamTraitStub[belongsTo]' );
+        $stub->shouldReceive('belongsTo')
             ->once()
             ->with('User', 'user_id', 'owner_id' )
             ->andReturn( [] );


### PR DESCRIPTION
Apparently the PR #100 (trying to fix #99) didn't work out.
This is a new attempt :-)

---

TeamworkTeamTrait::owner() method now returns a \Illuminate\Database\Eloquent\Relations\BelongsTo to be inline with current standards on relationships

