### PR TITLE
Support 5.8 fully (including for new installs)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable" : true,
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.5.*|5.6.*|5.7.*"
+        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",

--- a/src/database/migrations/2016_05_18_000000_teamwork_setup_tables.php
+++ b/src/database/migrations/2016_05_18_000000_teamwork_setup_tables.php
@@ -29,7 +29,7 @@ class TeamworkSetupTables extends Migration
 
         Schema::create( \Config::get( 'teamwork.team_user_table' ), function ( Blueprint $table )
         {
-            $table->integer( 'user_id' )->unsigned();
+            $table->bigInteger( 'user_id' )->unsigned();
             $table->integer( 'team_id' )->unsigned();
             $table->timestamps();
 
@@ -48,7 +48,7 @@ class TeamworkSetupTables extends Migration
         Schema::create( \Config::get( 'teamwork.team_invites_table' ), function(Blueprint $table)
         {
             $table->increments('id');
-            $table->integer('user_id')->unsigned();
+            $table->bigInteger('user_id')->unsigned();
             $table->integer('team_id')->unsigned();
             $table->enum('type', ['invite', 'request']);
             $table->string('email');


### PR DESCRIPTION
Laravel 5.8 is out, and I see a few requests for updating this library (which I very much appreciate and enjoy using) - but #107 and #108 don't fix the migration to support new users installing from scratch due to the changes on the `user` table. 

This pull request adds:

-  support in composer for satisfying 5.8 
- Changes `create` migration to `bigInteger` so the foreign keys don't break when installing on fresh 5.8