### PR TITLE
Move team guard check to the actual use case

### DIFF
--- a/src/Traits/UsedByTeams.php
+++ b/src/Traits/UsedByTeams.php
@@ -30,9 +30,9 @@ trait UsedByTeams
         });
 
         static::saving(function (Model $model) {
-            static::teamGuard();
-
             if (!isset($model->team_id)) {
+                static::teamGuard();
+
                 $model->team_id = auth()->user()->currentTeam->getKey();
             }
         });


### PR DESCRIPTION
This pull request adds the ability to add factories in combination with teams. As we're creating a instance with a team attached in our factory, but no one is authenticated at the moment, the `saving` closure triggers the 'No authenticated user with selected team present.'

This ensures the check is only done when necessary, that case would be when the team actually needs to be fetched from the authenticated user.