### PR TITLE
Append table name to Builder to prevent conflicting `ID`s in SQL query

### DIFF
--- a/src/Traits/TeamworkTeamTrait.php
+++ b/src/Traits/TeamworkTeamTrait.php
@@ -49,6 +49,6 @@ trait TeamworkTeamTrait
      */
     public function hasUser(Model $user)
     {
-        return $this->users()->where($user->getKeyName(), '=', $user->getKey())->first() ? true : false;
+        return $this->users()->where($model->getTable() . $user->getKeyName(), '=', $user->getKey())->first() ? true : false;
     }
 }

--- a/src/Traits/TeamworkTeamTrait.php
+++ b/src/Traits/TeamworkTeamTrait.php
@@ -49,6 +49,6 @@ trait TeamworkTeamTrait
      */
     public function hasUser(Model $user)
     {
-        return $this->users()->where($model->getTable() . $user->getKeyName(), '=', $user->getKey())->first() ? true : false;
+        return $this->users()->where($user->getTable() . $user->getKeyName(), '=', $user->getKey())->first() ? true : false;
     }
 }

--- a/src/Traits/TeamworkTeamTrait.php
+++ b/src/Traits/TeamworkTeamTrait.php
@@ -49,6 +49,6 @@ trait TeamworkTeamTrait
      */
     public function hasUser(Model $user)
     {
-        return $this->users()->where($user->getTable() . $user->getKeyName(), '=', $user->getKey())->first() ? true : false;
+        return $this->users()->where($user->getTable() . '.' . $user->getKeyName(), '=', $user->getKey())->first() ? true : false;
     }
 }

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -146,4 +146,9 @@ class TestUser extends \Illuminate\Database\Eloquent\Model
 class TestUserTeamTraitStub extends \Illuminate\Database\Eloquent\Model
 {
     use TeamworkTeamTrait;
+
+    public function getTable()
+    {
+        return 'teams_users';
+    }
 }

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -86,7 +86,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('user_id', '=', 'key')
+            ->with('users.user_id', '=', 'key')
             ->andReturnSelf();
 
         $stub->shouldReceive('users')

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -144,7 +144,7 @@ class TestUser extends \Illuminate\Database\Eloquent\Model
 
     public function getKey()
     {
-        return 'id';
+        return 'key';
     }
 }
 

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -91,7 +91,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('$this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
+            ->with($this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -120,7 +120,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('$this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
+            ->with($this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -75,10 +75,15 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
     {
         $stub = m::mock('\Mpociot\Teamwork\Tests\Feature\TestUserTeamTraitStub[users,first]');
 
-        $user = m::mock('\Mpociot\Teamwork\Tests\Feature\TestUser[getKey]');
+        $user = m::mock('\Mpociot\Teamwork\Tests\Feature\TestUser[getKey, getTable]');
+
         $user->shouldReceive('getKey')
             ->once()
             ->andReturn('key');
+
+        $user->shouldReceive('getTable')
+            ->once()
+            ->andReturn('users');
 
         $stub->shouldReceive('first')
             ->once()
@@ -86,7 +91,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('users.user_id', '=', 'key')
+            ->with('$this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')
@@ -99,10 +104,15 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
     {
         $stub = m::mock('\Mpociot\Teamwork\Tests\Feature\TestUserTeamTraitStub[users,first]');
 
-        $user = m::mock('\Mpociot\Teamwork\Tests\Feature\TestUser[getKey]');
+        $user = m::mock('\Mpociot\Teamwork\Tests\Feature\TestUser[getKey, getTable]');
+
         $user->shouldReceive('getKey')
             ->once()
             ->andReturn('key');
+
+        $user->shouldReceive('getTable')
+            ->once()
+            ->andReturn('users');
 
         $stub->shouldReceive('first')
             ->once()
@@ -110,7 +120,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('users.user_id', '=', 'key')
+            ->with('$this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')
@@ -125,6 +135,11 @@ class TestUser extends \Illuminate\Database\Eloquent\Model
     public function getKeyName()
     {
         return 'user_id';
+    }
+
+    public function getTable()
+    {
+        return 'users';
     }
 }
 

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -91,7 +91,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('users.user_id', '=', $this->user->getKey())
+            ->with('users.user_id', '=', 'key')
             ->andReturnSelf();
 
         $stub->shouldReceive('users')
@@ -120,7 +120,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('users.user_id', '=', $this->user->getKey())
+            ->with('users.user_id', '=', 'key')
             ->andReturnSelf();
 
         $stub->shouldReceive('users')

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -110,7 +110,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('user_id', '=', 'key')
+            ->with('users.user_id', '=', 'key')
             ->andReturnSelf();
 
         $stub->shouldReceive('users')

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -91,7 +91,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('users.user_id, '=', $this->user->getKey())
+            ->with('users.user_id', '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')
@@ -120,7 +120,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with('users.user_id, '=', $this->user->getKey())
+            ->with('users.user_id', '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -91,7 +91,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with($this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
+            ->with('users.user_id, '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')
@@ -120,7 +120,7 @@ class TeamworkTeamTraitTest extends \PHPUnit\Framework\TestCase
 
         $stub->shouldReceive('where')
             ->once()
-            ->with($this->user->getTable() . '.' . $this->user->getKeyName(), '=', $this->user->getKey())
+            ->with('users.user_id, '=', $this->user->getKey())
             ->andReturnSelf();
 
         $stub->shouldReceive('users')
@@ -146,9 +146,4 @@ class TestUser extends \Illuminate\Database\Eloquent\Model
 class TestUserTeamTraitStub extends \Illuminate\Database\Eloquent\Model
 {
     use TeamworkTeamTrait;
-
-    public function getTable()
-    {
-        return 'teams_users';
-    }
 }

--- a/tests/Feature/TeamworkTeamTraitTest.php
+++ b/tests/Feature/TeamworkTeamTraitTest.php
@@ -141,6 +141,11 @@ class TestUser extends \Illuminate\Database\Eloquent\Model
     {
         return 'users';
     }
+
+    public function getKey()
+    {
+        return 'id';
+    }
 }
 
 class TestUserTeamTraitStub extends \Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
Fixes the issue "Column 'id' in where clause is ambiguous" when using additional scopes.

Example query that fails due to not specifying the table name for `id`:

SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous (SQL: select `users`.*, `tenants_user`.`team_id` as `pivot_team_id`, `tenants_user`.`user_id` as `pivot_user_id`, `tenants_user`.`created_at` as `pivot_created_at`, `tenants_user`.`updated_at` as `pivot_updated_at` from `users` inner join `tenants_user` on `users`.`id` = `tenants_user`.`user_id` where `tenants_user`.`team_id` = 2 and `id` = 1 and `users`.`deleted_at` is null limit 1)