### PR TITLE
Switch currentTeam relationship from hasOne to belongsTo

### DIFF
--- a/src/Traits/UserHasTeams.php
+++ b/src/Traits/UserHasTeams.php
@@ -22,13 +22,13 @@ trait UserHasTeams
     }
 
     /**
-     * has-one relation with the current selected team model.
+     * Belongs-to relation with the current selected team model.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function currentTeam()
     {
-        return $this->hasOne(Config::get('teamwork.team_model'), 'id', 'current_team_id');
+        return $this->belongsTo(Config::get('teamwork.team_model'), 'current_team_id', 'id');
     }
 
     /**


### PR DESCRIPTION
I believe there's a mistake on the type of relationship currentTeam should be.

As a `current_team_id` is added to the `users` table, the relationship between a user and a team should be belongsTo.

I discovered the mistake by trying to use a UserFactory with the `->for()` method.

This would return a mistake `$relationship->getOwnerKeyName()` doesn't exist if you try to do
`User::factory()->for($team, 'currentTeam')->create()`