### PR TITLE
Added function createOwnedTeam to UserHasTeams

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ $user->teams()->attach($team->id); // id only
 
 By using the `attachTeam` method, if the User has no Teams assigned, the `current_team_id` column will automatically be set.
 
+Alternatively, you can also use `createOwnedTeam` method from `UserHasTeams` trait. It will create team for the user as owner, attach the user to the team and switch to the newly created team.
+
+```php
+// Create user owned team and switch the current team to this new team.
+$team = $user->createOwnedTeam(['name' => 'My awesome team']);
+
+// If user has another current team active, you should pass second parameter as true to force switch to the new team.
+$team = $user->createOwnedTeam(['name' => 'My awesome team'], true);
+```
+
+The function will return the newly created instance of your team model.
+
 ### Get to know my team(s)
 
 The currently assigned Team of a user can be accessed through the `currentTeam` relation like this:

--- a/src/Traits/UserHasTeams.php
+++ b/src/Traits/UserHasTeams.php
@@ -263,14 +263,22 @@ trait UserHasTeams
      * Create team for owner, add owner to the users and switch to the team.
      *
      * @param array $data
+     * @param bool $forceSwitchTeam
      * @return mixed
      */
-    public function createOwnedTeam($data)
+    public function createOwnedTeam($data, $forceSwitchTeam = false)
     {
         $teamModel = Config::get('teamwork.team_model');
         $team = $teamModel::create(array_merge($data, ['owner_id' => $this->id]));
 
         $this->attachTeam($team);
+
+        if (
+            $this->current_team_id !== $team->id &&
+            $forceSwitchTeam
+        ) {
+            $this->switchTeam($team);
+        }
 
         return $team;
     }

--- a/src/Traits/UserHasTeams.php
+++ b/src/Traits/UserHasTeams.php
@@ -258,4 +258,20 @@ trait UserHasTeams
 
         return $this;
     }
+
+    /**
+     * Create team for owner, add owner to the users and switch to the team.
+     *
+     * @param array $data
+     * @return mixed
+     */
+    public function createOwnedTeam($data)
+    {
+        $teamModel = Config::get('teamwork.team_model');
+        $team = $teamModel::create(array_merge($data, ['owner_id' => $this->id]));
+
+        $this->attachTeam($team);
+
+        return $team;
+    }
 }

--- a/tests/Feature/UserHasTeamsTraitTest.php
+++ b/tests/Feature/UserHasTeamsTraitTest.php
@@ -315,4 +315,13 @@ class UserHasTeamsTraitTest extends TestCase
         $this->expectException('Illuminate\Database\Eloquent\ModelNotFoundException');
         $this->user->switchTeam(3);
     }
+
+    public function testTeamForOwnerCanBeCreated()
+    {
+        $team = $this->user->createOwnedTeam(['name' => 'test']);
+
+        $this->assertTrue($this->user->isOwnerOfTeam($team));
+        $this->assertTrue($team->hasUser($this->user));
+        $this->assertEquals($this->user->currentTeam->id, $team->id);
+    }
 }

--- a/tests/Feature/UserHasTeamsTraitTest.php
+++ b/tests/Feature/UserHasTeamsTraitTest.php
@@ -316,12 +316,28 @@ class UserHasTeamsTraitTest extends TestCase
         $this->user->switchTeam(3);
     }
 
-    public function testTeamForOwnerCanBeCreated()
+    public function testTeamForOwnerCanBeCreatedAndSwitchToTeamIfNoTeamExists()
     {
         $team = $this->user->createOwnedTeam(['name' => 'test']);
 
         $this->assertTrue($this->user->isOwnerOfTeam($team));
         $this->assertTrue($team->hasUser($this->user));
         $this->assertEquals($this->user->currentTeam->id, $team->id);
+    }
+
+    public function testTeamForOwnerCanBeCreatedAndNotSwitchToTeamIfTeamExists()
+    {
+        $firstTeam = $this->user->createOwnedTeam(['name' => 'test']);
+        $anotherTeam = $this->user->createOwnedTeam(['name' => 'Another test']);
+
+        $this->assertEquals($this->user->currentTeam->id, $firstTeam->id);
+    }
+
+    public function testTeamForOwnerCanBeCreatedAndCanSwitchToNewTeam()
+    {
+        $firstTeam = $this->user->createOwnedTeam(['name' => 'test']);
+        $anotherTeam = $this->user->createOwnedTeam(['name' => 'Another test'], true);
+
+        $this->assertEquals($this->user->currentTeam->id, $anotherTeam->id);
     }
 }


### PR DESCRIPTION
Added a new function `createOwnedTeam` to the `UserHasTeams` trait, which can allow the developers to quickly implement the team creation without repeating 4-5 lines of code.

The existing process for doing this is something like this:

```php
$team = Team::create(['name'=> 'My team', 'owner_id' => $user->id]));

$user->attachTeam($team);

// If user already have any other current team, we have to separately switch team
$user->switchTeam($team);
```

The new function does all this behind the scenes:
```php
// If this is first team of user, user's current team will be this new team
$team = $user->createOwnedTeam(['name' => 'My awesome team']);

// If the user has teams, we want the user to switch to this new team, pass second parameter true to this method.
$team = $user->createOwnedTeam(['name' => 'My awesome team'], true);
```