### PR TITLE
Use a more sane default for user_model config option

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -9,7 +9,7 @@ return [
     | This is the Auth model used by Teamwork.
     |
     */
-    'user_model' => config('auth.providers.users.model', App\User::class),
+    'user_model' => config('auth.providers.users.model', App\Models\User::class),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Laravel's user model by default is stored in `App\Models` not in `App`: https://github.com/laravel/laravel/blob/11.x/app/Models/User.php

Since this is Laravel's default, makes sense that we default to this also.