### PR TITLE
Use big integers to match Laravel

### DIFF
--- a/database/migrations/2016_05_18_000000_teamwork_setup_tables.php
+++ b/database/migrations/2016_05_18_000000_teamwork_setup_tables.php
@@ -17,7 +17,7 @@ class TeamworkSetupTables extends Migration
         });
 
         Schema::create(\Config::get('teamwork.teams_table'), function (Blueprint $table) {
-            $table->bigIncrements('id')->unsigned();
+            $table->id();
             $table->bigInteger('owner_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
@@ -41,7 +41,7 @@ class TeamworkSetupTables extends Migration
         });
 
         Schema::create(\Config::get('teamwork.team_invites_table'), function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->bigInteger('user_id')->unsigned();
             $table->bigInteger('team_id')->unsigned();
             $table->enum('type', ['invite', 'request']);

--- a/database/migrations/2016_05_18_000000_teamwork_setup_tables.php
+++ b/database/migrations/2016_05_18_000000_teamwork_setup_tables.php
@@ -13,19 +13,19 @@ class TeamworkSetupTables extends Migration
     public function up()
     {
         Schema::table(\Config::get('teamwork.users_table'), function (Blueprint $table) {
-            $table->integer('current_team_id')->unsigned()->nullable();
+            $table->bigInteger('current_team_id')->unsigned()->nullable();
         });
 
         Schema::create(\Config::get('teamwork.teams_table'), function (Blueprint $table) {
-            $table->increments('id')->unsigned();
-            $table->integer('owner_id')->unsigned()->nullable();
+            $table->bigIncrements('id')->unsigned();
+            $table->bigInteger('owner_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });
 
         Schema::create(\Config::get('teamwork.team_user_table'), function (Blueprint $table) {
             $table->bigInteger('user_id')->unsigned();
-            $table->integer('team_id')->unsigned();
+            $table->bigInteger('team_id')->unsigned();
             $table->timestamps();
 
             $table->foreign('user_id')
@@ -41,9 +41,9 @@ class TeamworkSetupTables extends Migration
         });
 
         Schema::create(\Config::get('teamwork.team_invites_table'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned();
-            $table->integer('team_id')->unsigned();
+            $table->bigInteger('team_id')->unsigned();
             $table->enum('type', ['invite', 'request']);
             $table->string('email');
             $table->string('accept_token');


### PR DESCRIPTION
Laravel's default now uses `bigInteger` and `bigIncrements` where needed for integer ID values in the database. As you can see [here](https://github.com/laravel/laravel/blob/8b67958f49054f3e6c9b61d2e0b0a1e5323f30f4/database/migrations/0001_01_01_000000_create_users_table.php#L15) Laravel uses `$table->id()` in the default `users` table migration which in the latest version of Laravel uses `bigIncrements`:

https://github.com/laravel/framework/blob/e1db317e7dafa8867b0eada6f89393419ed84cb0/src/Illuminate/Database/Schema/Blueprint.php#L744