### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,29 +12,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
-        laravel: ['9.*', '10.*', '11.*', '12.*']
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
           - laravel: 11.*
             php: 8.1
-          - laravel: 11.*
-            php: 8.0
           - laravel: 12.*
             php: 8.1
-          - laravel: 12.*
-            php: 8.0
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
+        "php": "^8.1",
+        "laravel/framework": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.5.1",
-        "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "mockery/mockery": "^1.6.12",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "doctrine/dbal": "^2.10|^3.5|^4.2"
     },
     "config": {


### PR DESCRIPTION
Add support for Laravel 13 and drop support for Laravel 9.

I'm not sure if this is the best approach, but the only way I found to overcome the incompatibility was dropping support for PHP 8.0 and Laravel 9.

The minimum supported PHP version for this release is 8.1.
The minimum supported Laravel version is 10.

Fixes errors in  https://github.com/mpociot/teamwork/pull/165 caused by an outdated illuminate/database version.